### PR TITLE
docs(readme): clarify report signing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ goop-veil report capture.pcap
 
 If you are evaluating router support first, see [docs/ROUTER_COMPATIBILITY.md](./docs/ROUTER_COMPATIBILITY.md).
 
+## Contributor setup for report signing
+
+Use this path when you want locally generated report artifacts to remain verifiable after the process exits.
+
+```bash
+python - <<'PY'
+import base64, os, secrets
+print(base64.b64encode(secrets.token_bytes(32)).decode())
+PY
+export VEIL_LOG_SIGNING_KEY="<paste-base64-key-here>"
+```
+
+Artifact verification states:
+- `signed`: durably verifiable; requires an explicit signing key via `VEIL_LOG_SIGNING_KEY` or direct configuration
+- `temporary_signed`: explicit dev/test mode only; uses a random in-memory key and stops being verifiable once that key is lost
+- unsigned output: only valid when a caller intentionally chooses a non-signed path; it should not be described as signed or durable
+
+For contributor-facing caveats and limitations, also see [docs/KNOWN_LIMITATIONS.md](./docs/KNOWN_LIMITATIONS.md) and [docs/FAQ.md](./docs/FAQ.md).
+
 ---
 
 ## CLI Commands

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -27,6 +27,19 @@ The project is designed around local workflows. Optional sharing/integration fea
 ## Can this help with reporting?
 Yes — the project can generate documentation artifacts that may help with internal records and reporting workflows. Whether a specific response path makes sense depends on context.
 
+## How do I make report artifacts durably verifiable during local testing?
+Set `VEIL_LOG_SIGNING_KEY` before running report-generation flows. The value must be base64-encoded key material.
+
+```bash
+python - <<'PY'
+import base64, secrets
+print(base64.b64encode(secrets.token_bytes(32)).decode())
+PY
+export VEIL_LOG_SIGNING_KEY="<paste-base64-key-here>"
+```
+
+If you explicitly enable temporary dev/test signing instead, generated artifacts are only temporarily verifiable for the lifetime of that in-memory key.
+
 ## Are the report packages court-ready?
 No guarantee is made that generated artifacts will satisfy any court, regulator, or agency requirement. They are technical documentation artifacts that may help with internal review or reporting workflows.
 


### PR DESCRIPTION
## Why
Contributors have reporting/signing guidance scattered across issue notes and limitations docs, but not one obvious setup path for local testing. That leaves the verification state of generated artifacts easy to misunderstand.

## What changed
- add a contributor-facing `VEIL_LOG_SIGNING_KEY` setup section to `README.md`
- explain the difference between `signed`, `temporary_signed`, and intentionally unsigned output
- add the same local-testing guidance to `docs/FAQ.md`

## Verification
- `pytest -q tests/test_mitigation/test_reporting/test_log_exporter.py`
- result: `18 passed in 0.05s`

Closes #12
