### PR TITLE
docs(readme): add signing key setup note for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ goop-veil report capture.pcap
 
 If you are evaluating router support first, see [docs/ROUTER_COMPATIBILITY.md](./docs/ROUTER_COMPATIBILITY.md).
 
+### Contributor note: evidence signing for local testing
+
+If you are working on reporting or evidence-generation paths, set `VEIL_LOG_SIGNING_KEY` before testing durable signed artifacts. Without that key, outputs should be treated as either unsigned or temporary dev/test artifacts rather than durably verifiable evidence.
+
+```bash
+python - <<'PY2'
+import base64, secrets
+print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())
+PY2
+export VEIL_LOG_SIGNING_KEY='<paste-generated-key>'
+```
+
+Use this only for local development. Public docs and PRs should not imply courtroom, certification, or permanence guarantees for generated artifacts.
+
 ---
 
 ## CLI Commands


### PR DESCRIPTION
## Summary
- add one obvious contributor-facing setup section for `VEIL_LOG_SIGNING_KEY` in the README quick-start path
- explain that durable signed artifacts require an explicit key
- clarify that missing-key outputs should be treated as unsigned or temporary dev/test artifacts, not durably verifiable evidence

## Why
Issue #12 asks for one obvious contributor path that explains local signing-key setup without overstating the legal or certification posture of generated artifacts. The runtime and tests already enforce this behavior, but the README did not surface it where contributors are most likely to look first.

## Scope
Included:
- README contributor note with a local key-generation example
- wording that points contributors toward the existing verification-state boundaries

Not included:
- runtime behavior changes
- new CLI flags or reporting implementation changes
- broader docs restructuring

## Risk Review
- [ ] Router state changes / auto-apply behavior
- [ ] Security defaults / auth / transport / confirmation flow
- [ ] Reporting / documentation artifact generation
- [ ] Firmware / hardware behavior
- [ ] MCP / tool invocation surface
- [x] Public-facing docs / README / launch copy
- [ ] Privacy / redaction / data handling

This change is docs-only. It aligns the public contributor path with the already-tested signing behavior and avoids stronger claims about artifact permanence or admissibility.

## Validation
What did you run or verify?
- [x] Unit tests
- [ ] Integration or smoke tests
- [ ] Manual verification
- [x] Docs review
- [ ] Example CLI flow

Commands / notes:
```bash
python3 -m pytest tests/test_cli.py tests/test_terminology_compliance.py -q
python3 -m pytest tests/test_mitigation/test_reporting/test_log_exporter.py tests/test_mitigation/test_reporting/test_package.py -q
```

## User-visible impact
What changes for:
- operators? clearer expectations about what counts as durable signed output
- contributors? one obvious README path for generating and exporting a local signing key
- reviewers? README language now matches the tested runtime behavior more directly
- launch/public messaging? reduces ambiguity around verification state without changing product claims

## Docs / Truth Alignment
- [x] README updated if behavior changed
- [x] FAQ / Known Limitations updated if needed
- [x] Public claims still match implementation
- [x] Experimental vs supported scope is still accurate

## Follow-ups
- consider linking directly to the contributor note from any future evidence/reporting issue templates if maintainers want an even more explicit path
